### PR TITLE
HACK-1219: remove deprecation calls 

### DIFF
--- a/index.php
+++ b/index.php
@@ -38,9 +38,12 @@ $course = $DB->get_record('course', array('id' => $id), '*', MUST_EXIST);
 
 require_course_login($course);
 
-add_to_log($course->id, 'clickmeeting', 'view all', 'index.php?id='.$course->id, '');
+$event = \mod_clickmeeting\event\course_module_instance_list_viewed::create(array(
+    'context' => context_course::instance($course->id)
+));
+$event->trigger();
 
-$coursecontext = get_context_instance(CONTEXT_COURSE, $course->id);
+$coursecontext = context_module::instance($course->id);
 
 $PAGE->set_url('/mod/clickmeeting/index.php', array('id' => $id));
 $PAGE->set_title(format_string($course->fullname));

--- a/lang/en/clickmeeting.php
+++ b/lang/en/clickmeeting.php
@@ -75,3 +75,7 @@ $string['clickmeeting:addinstance'] = 'Adding';
 $string['clickmeeting:host'] = 'Host';
 $string['clickmeeting:listener'] = 'Listener';
 $string['clickmeeting:presenter'] = 'Presenter';
+
+$string['startdate_booked'] = 'This start date is already booked';
+$string['update_error'] = 'Error updating record';
+$string['api_404_error'] = '404 Not Found';

--- a/lang/pl/clickmeeting.php
+++ b/lang/pl/clickmeeting.php
@@ -75,3 +75,7 @@ $string['clickmeeting:addinstance'] = 'Dodawanie';
 $string['clickmeeting:host'] = 'Organizator';
 $string['clickmeeting:listener'] = 'Uczestnik';
 $string['clickmeeting:presenter'] = 'Prezenter';
+
+$string['startdate_booked'] = 'Nie można utworzyć konferencji dla tej daty';
+$string['update_error'] = 'Błąd przy aktualizacji wpisu';
+$string['api_404_error'] = '404 Not Found';

--- a/lib.php
+++ b/lib.php
@@ -321,8 +321,7 @@ function clickmeeting_add_instance(stdClass $clickmeeting, mod_clickmeeting_mod_
     $clickmeeting->user_id = $USER->id;
 
     if (!clickmeeting_check_conference_availability($clickmeeting->start_time, $clickmeeting->duration)) {
-        print_error('This start date is already booked', '', course_get_url($COURSE, $cw->section));
-        return false;
+        throw new \moodle_exception('startdate_booked', 'clickmeeting');
     }
 
     $transaction = $DB->start_delegated_transaction();
@@ -351,7 +350,7 @@ function clickmeeting_add_instance(stdClass $clickmeeting, mod_clickmeeting_mod_
             foreach ($r['errors'] as $err) {
                 $error .= $err['message'].'<br />';
             }
-            print_error($error, '', course_get_url($COURSE, $cw->section));
+            throw new \moodle_exception($error, 'error');
         }
 
         if (isset($r['room'])) {
@@ -397,18 +396,15 @@ function clickmeeting_update_instance(stdClass $clickmeeting, mod_clickmeeting_m
     $conference = $DB->get_record('clickmeeting_conferences', array('clickmeeting_id' => $clickmeeting->id));
 
     if (!clickmeeting_check_conference_availability($clickmeeting->start_time, $clickmeeting->duration, $conference->conference_id)) {
-        print_error('This start date is already booked', '', course_get_url($COURSE, $cw->section));
-        return false;
+        throw new \moodle_exception('startdate_booked', 'clickmeeting');
     }
 
     if (!$DB->update_record('clickmeeting', $clickmeeting)) {
-        print_error('Error updating record', '', course_get_url($COURSE, $cw->section));
-        return false;
+        throw new \moodle_exception('update_error', 'clickmeeting');
     }
 
     $params['name'] = $clickmeeting->name;
     $params['room_type'] = $clickmeeting->room_type;
-    $params['lobby_description'] = $clickmeeting->lobby_msg;
     $params['duration'] = $clickmeeting->duration;
     $params['permanent_room'] = '0';
     $params['access_type'] = $clickmeeting->access_type;
@@ -436,8 +432,7 @@ function clickmeeting_update_instance(stdClass $clickmeeting, mod_clickmeeting_m
         foreach ($r['errors'] as $err) {
             $error .= $err['message'].'<br />';
         }
-        print_error($error, '', course_get_url($COURSE, $cw->section));
-        return false;
+        throw new \moodle_exception($error, 'error');
     }
 
     $transaction->allow_commit();
@@ -476,8 +471,7 @@ function clickmeeting_delete_instance($id)
     if ('"200 OK"' != $apiresult) {
         // jezeli nie znajdujemy conferencji w clickmeetingu to nie trzeba jej tam usuwac
         if ('"404 Not Found"' == $apiresult) {
-            print_error($apiresult);
-            return false;
+            throw new \moodle_exception('api_404_error', 'clickmeeting');
         }
     }
 

--- a/version.php
+++ b/version.php
@@ -30,8 +30,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2019071811;
-$plugin->requires = 2013051400; // Requires this Moodle 2.5 version
+$plugin->version = 2024031261;
+$plugin->requires = 2013111811.01; // Requires this Moodle 2.6 version
 $plugin->maturity = MATURITY_STABLE;
 $plugin->cron = 0;
 $plugin->component = 'mod_clickmeeting';


### PR DESCRIPTION
* removes calls to deprecated function:
** print_error
** add_to_log
** get_context_instance
* bumps minimum Moodle requirements due to new event logging